### PR TITLE
Check object/property exists first

### DIFF
--- a/wat/scripts/css_hiddentovisible.ws
+++ b/wat/scripts/css_hiddentovisible.ws
@@ -1,17 +1,11 @@
 ﻿function main(){
-
-for(i = 0; i < f_length; i++){
- for(z=0;z<GetFrame(i).document.all.length;z++){    
-
-
-if (GetFrame(i).document.all[z].currentStyle.visibility=='hidden')
-{
-
-GetFrame(i).document.all[z].style.visibility='visible';
-GetFrame(i).document.all[z].style.border='1px dotted #228b22';
-}
-
-}
-}
-
+	for(i = 0; i < f_length; i++){
+		for(z=0;z<GetFrame(i).document.all.length;z++){    
+			if ((GetFrame(i).document.all[z].currentStyle.visibility)&&(GetFrame(i).document.all[z].currentStyle.visibility=='hidden'))
+			{
+				GetFrame(i).document.all[z].style.visibility='visible';
+				GetFrame(i).document.all[z].style.border='1px dotted #228b22';
+			}
+		}
+	}
 }

--- a/wat/scripts/css_nonetoinline.ws
+++ b/wat/scripts/css_nonetoinline.ws
@@ -1,17 +1,11 @@
 ﻿function main(){
-
-for(i = 0; i < f_length; i++){
- for(z=0;z<GetFrame(i).document.all.length;z++){    
-
-
-if (GetFrame(i).document.all[z].currentStyle.display=='none')
-{
-
-GetFrame(i).document.all[z].style.display='inline-block';
-GetFrame(i).document.all[z].style.border='1px dotted #b22222';
-}
-
-}
-}
-
+	for(i = 0; i < f_length; i++){
+ 		for(z=0;z<GetFrame(i).document.all.length;z++){    
+			if ((GetFrame(i).document.all[z].currentStyle.display)&&(GetFrame(i).document.all[z].currentStyle.display=='none'))
+			{
+				GetFrame(i).document.all[z].style.display='inline-block';
+				GetFrame(i).document.all[z].style.border='1px dotted #b22222';
+			}
+		}
+	}
 }

--- a/wat/scripts/offscreen.ws
+++ b/wat/scripts/offscreen.ws
@@ -1,21 +1,17 @@
 ﻿function main(){
-
-for(i = 0; i < f_length; i++){
- for(z=0;z<GetFrame(i).document.all.length;z++){    
-if (parseInt(GetFrame(i).document.all[z].currentStyle.left, 10)<=-50||parseInt(GetFrame(i).document.all[z].currentStyle.top, 10)<=-50||parseInt(GetFrame(i).document.all[z].currentStyle.textIndent, 10)<=-50)
-{
-
-GetFrame(i).document.all[z].style.top='0';
-GetFrame(i).document.all[z].style.left='0';
-GetFrame(i).document.all[z].style.textIndent='0';
-GetFrame(i).document.all[z].style.display='block';
-GetFrame(i).document.all[z].style.position='relative';
-GetFrame(i).document.all[z].style.backgroundColor='#ffffff';
-GetFrame(i).document.all[z].style.color='#000000';
-GetFrame(i).document.all[z].style.zIndex='5000';
-}
-
-}
-}
-
+	for(i = 0; i < f_length; i++){
+		for(z=0;z<GetFrame(i).document.all.length;z++){    
+			if ( ((GetFrame(i).document.all[z].currentStyle.left)&&(parseInt(GetFrame(i).document.all[z].currentStyle.left, 10)<=-50)) || ((GetFrame(i).document.all[z].currentStyle.top)&&(parseInt(GetFrame(i).document.all[z].currentStyle.top, 10)<=-50)) || ((GetFrame(i).document.all[z].currentStyle.textIndent)&&(parseInt(GetFrame(i).document.all[z].currentStyle.textIndent, 10)<=-50)) )
+			{
+				GetFrame(i).document.all[z].style.top='0';
+				GetFrame(i).document.all[z].style.left='0';
+				GetFrame(i).document.all[z].style.textIndent='0';
+				GetFrame(i).document.all[z].style.display='block';
+				GetFrame(i).document.all[z].style.position='relative';
+				GetFrame(i).document.all[z].style.backgroundColor='#ffffff';
+				GetFrame(i).document.all[z].style.color='#000000';
+				GetFrame(i).document.all[z].style.zIndex='5000';
+			}
+		}
+	}
 }


### PR DESCRIPTION
Avoids (hopefully...untested) unsightly JS errors a la "``document.all[...].currentStyle.display``
is null or not an object", followed by the "OLE エラー 80020101" error
message.

Also conforms those two ``.ws`` files to the "use tabs" recommended style (assuming this does not cause problems in the way the IE toolbar scripts work)

![css-display-none-to-inline](https://cloud.githubusercontent.com/assets/895831/6076870/b7c1d1e0-ade0-11e4-830d-e6f4ed72fb20.PNG)

![css-display-none-to-inline2](https://cloud.githubusercontent.com/assets/895831/6076865/ab789ad6-ade0-11e4-8b9a-09f6f906f7f1.PNG)