### PR TITLE
Fix browser sniff (for "show focus")

### DIFF
--- a/wat/Translation.ini
+++ b/wat/Translation.ini
@@ -583,7 +583,7 @@ other_struc=ws:scripts/show-other.ws
 other_aria=ws:scripts/show-aria.ws
 # show_focus=ws:scripts/ShowFocus.js
 # show_focus=javascript:void(function() {var css=document.createElement("style");css.type="text/css";css.innerHTML="a:hover, a:focus, a:active, input:focus, textfield:focus, button:focus {background-color: #ff9; outline: 4px solid #c00;};}";document.getElementsByTagName('head')[0].appendChild(css);})()
-show_focus=javascript:(function(){var ua=navigator.userAgent.toLowerCase(),ie=ua.indexOf("msie")!=-1?ua.substr(ie+5,1):0,outlineProp=ie<8?"border":"outline",activeItem;function styleFocus(e){if(activeItem){activeItem.style[outlineProp]="";}activeItem=e.target||e.srcElement;if(activeItem){activeItem.style[outlineProp]="solid 2px red";}}if(document.addEventListener){document.addEventListener("focus",styleFocus,true);}else{document.attachEvent("onfocusin",styleFocus);}}());
+show_focus=javascript:(function(){var ua=navigator.userAgent.toLowerCase(),ie=ua.indexOf("msie")!=-1?ua.substr(ie+5,1):8,outlineProp=ie<8?"border":"outline",activeItem;function styleFocus(e){if(activeItem){activeItem.style[outlineProp]="";}activeItem=e.target||e.srcElement;if(activeItem){activeItem.style[outlineProp]="solid 2px red";}}if(document.addEventListener){document.addEventListener("focus",styleFocus,true);}else{document.attachEvent("onfocusin",styleFocus);}}());
 jsread_tool=POST!http://juicystudio.com/services/readability.php{url=%url}
 wave_tool=http://wave.webaim.org/Output.jsp?InputUrlText=%url
 ##tenon_tool=http://tenon.io/#testnow


### PR DESCRIPTION
Currently IE11 evaluates to "0", which then counts as being IE<8.

https://github.com/ThePacielloGroup/WebAccessibilityToolbar/issues/41
